### PR TITLE
Fix typos and grammar across blog posts

### DIFF
--- a/_posts/2023-05-09-IPL.md
+++ b/_posts/2023-05-09-IPL.md
@@ -61,6 +61,6 @@ There are 2 clear ways out for Jio right now, in **increasing** order of priorit
 	- Speak the language of the advertisers: While Jio is doing the usual CPM based inventory which is common for digital, they are also selling the more native 10 second ad slots that TV advertisers are more familiar with. This gives the budget holders a very easy comparison point given it fits their existing mental models.
 
 -------
-While Jio has not been able to increase it's ad share pie instantly, this was expected given native TV advertisers being hesistant and okay with waiting out for one season. They also have a huge line up of Originals (~100 new shows and movies) that they announced post the start of the IPL (and apparently had been under the hood for [4 years now](https://www.linkedin.com/feed/update/urn:li:activity:7052136203944402944/))
+While Jio has not been able to increase it's ad share pie instantly, this was expected given native TV advertisers being hesitant and okay with waiting out for one season. They also have a huge line up of Originals (~100 new shows and movies) that they announced post the start of the IPL (and apparently had been under the hood for [4 years now](https://www.linkedin.com/feed/update/urn:li:activity:7052136203944402944/))
 
 **The next few IPL seasons are going to be really interesting with how Jio's end game pans out.**

--- a/_posts/2025-02-08-granola.md
+++ b/_posts/2025-02-08-granola.md
@@ -3,15 +3,14 @@ layout: default
 title: "Granola AI - def a better note taker but not because of its AI"
 permalink: /writings/png/granola
 categories: [writings, png]
-image: /assets/images/png/Pasted image 20250406161504.png
 ---
 
 <small>{{ page.date | date_to_string }}</small>
-# Granola App - def a better note taker but not because of it's AI
+# Granola App - def a better note taker but not because of its AI
 
 Lots of love recently for [Granola app](https://www.granola.ai/) (founders of Intercom, Linear, Vercel below)!
 
-I have been a user for ~4 months now and my tl;dr: it's a really good meeting notes app, but only because of it's seamless design choices and not due to AI. Let's dive in!
+I have been a user for ~4 months now and my tl;dr: it's a really good meeting notes app, but only because of its seamless design choices and not due to AI. Let's dive in!
 
 ![granola-tweets](/assets/images/granola%20intercom.png)![granola-tweets2](/assets/images/granola%20linear.png)![granola-tweets3](/assets/images/granola%20vercel.png)
 
@@ -31,7 +30,7 @@ The workflow is pretty seamless:
 	   1 min before any meeting, a Mac notification pops up that allows you to join a meeting as well as open a Granola note for that meeting. No separate effort needed to start a note. It also "discovers" ad-hoc meetings like Slack huddles/adhoc scheduled google meets and gives a notification to start a Granola note for that call. Pretty smart! ![granola-notification](/assets/images/granola%20huddle%20detected.png)
 	   
  3. **One central repository for most notes**
-	    So refreshing to have all of my individual notes reside in Granola & not go have to remember which slack thread, google doc, apple notes, obsidian vault did I make a note for which particular call. Ofcourse, multi-user notes still end up in a Google Doc auto-linked to the GCal invite (more on this later)
+	    So refreshing to have all of my individual notes reside in Granola & not go have to remember which slack thread, google doc, apple notes, obsidian vault did I make a note for which particular call. Of course, multi-user notes still end up in a Google Doc auto-linked to the GCal invite (more on this later)
 
 #### What is still not working for me?
 

--- a/_posts/2026-01-16-instapaper-bug.md
+++ b/_posts/2026-01-16-instapaper-bug.md
@@ -22,7 +22,7 @@ I had been a [Pocket](https://getpocket.com/home) user for the past 4-5 years as
 
 I, of course, got worried about what will happen to my *bazillion* saved-for-later articles/blogs/twitter-threads and all the magical information that is just waiting for me to consume and transform myself.
 
-After some research, I landed on [Instapaper](https://instapaper.com/). It has the typical chrome extension flow that can you can click on and save to your read-later queue, with the ability to add tags on the link *(remember tags for they are the hero of the story)*
+After some research, I landed on [Instapaper](https://instapaper.com/). It has the typical chrome extension flow that you can click on and save to your read-later queue, with the ability to add tags on the link *(remember tags for they are the hero of the story)*
 
 ![](/assets/images/instapaper/instapaper-2.png)
 

--- a/_posts/2026-01-26-how-to-level-up-with-claude-code.md
+++ b/_posts/2026-01-26-how-to-level-up-with-claude-code.md
@@ -79,7 +79,7 @@ My goal with this post is to:
 
 3. **Multiple terminals split in the same VS-code window**
 
-	h/t [Boris' tweet](https://x.com/bcherny/status/2007179833990885678). Once worktrees is working, you can split different Claude Code instances into different VS Code splits in the same window, such that you can automatically move b/w them with the ⌘+1/2/3 shortcut. Makes multi-tasking so much more easier!
+	h/t [Boris' tweet](https://x.com/bcherny/status/2007179833990885678). Once worktrees is working, you can split different Claude Code instances into different VS Code splits in the same window, such that you can automatically move b/w them with the ⌘+1/2/3 shortcut. Makes multi-tasking so much easier!
 
 	There is also the `Maximise Group` shortcut that can maximise just your current view if you want to deep focus on just one problem.
 	![](/assets/images/claude-code/claude-code-2.png)


### PR DESCRIPTION
## Summary
- Fix "it's" → "its" (possessive) and "Ofcourse" → "Of course" in Granola post
- Fix "hesistant" → "hesitant" in IPL post
- Remove extra "can" in Instapaper post ("can you can" → "you can")
- Fix "more easier" → "easier" in Claude Code post
- Remove broken image frontmatter reference in Granola post

## Test plan
- [ ] Verify posts render correctly on the site

https://claude.ai/code/session_01WVoLPmtKV1mEiwiufzVD9B