### PR TITLE
add inline subscribe section to vercel post, refresh copy

### DIFF
--- a/_includes/subscribe-form.html
+++ b/_includes/subscribe-form.html
@@ -1,20 +1,19 @@
 <!-- Variation selector: change 'data-variant' to 1, 2, 3, 4, or 5 -->
 <div class="subscribe-section" data-variant="3">
-  <form id="newsletter-form">
+  <form class="newsletter-form">
     <div class="subscribe-content">
-      <span class="subscribe-text">Get new posts in your inbox</span>
+      <span class="subscribe-text">I'm a PM who ships with AI tools and writes about what I find inside them. One email when I publish, nothing else.</span>
       <div class="subscribe-form-row">
         <input
           type="email"
-          id="newsletter-email"
           name="email"
           placeholder="your@email.com"
           required
           autocomplete="email"
         >
-        <button type="submit" id="newsletter-submit">Subscribe</button>
+        <button type="submit">Subscribe</button>
       </div>
     </div>
   </form>
-  <p class="form-message" id="form-message"></p>
+  <p class="form-message"></p>
 </div>

--- a/_posts/2026-04-09-vercel-plugin-telemetry.md
+++ b/_posts/2026-04-09-vercel-plugin-telemetry.md
@@ -28,6 +28,27 @@ That felt wrong. So I went deep into the source code with Claude.
 - *"Anonymous usage data" includes your full bash command strings sent to Vercel's servers. You're never told this is optional.*
 - *All of this runs on every project, not just Vercel ones. The plugin has framework detection built in - it just doesn't use it to gate telemetry.*
 
+<div class="subscribe-section" data-variant="3">
+  <form class="newsletter-form">
+    <div class="subscribe-content">
+      <span class="subscribe-text">I'm a PM who ships with AI tools and writes about what I find inside them. One email when I publish, nothing else.</span>
+      <div class="subscribe-form-row">
+        <input
+          type="email"
+          name="email"
+          placeholder="your@email.com"
+          required
+          autocomplete="email"
+        >
+        <button type="submit">Subscribe</button>
+        <span class="subscribe-divider">·</span>
+        <a href="https://x.com/akshaychugh_xyz" class="subscribe-x-link" target="_blank" rel="noopener noreferrer">Follow on X →</a>
+      </div>
+    </div>
+  </form>
+  <p class="form-message"></p>
+</div>
+
 ---
 
 ## Problem 1: The consent is fake

--- a/assets/css/typewriter.css
+++ b/assets/css/typewriter.css
@@ -761,6 +761,26 @@ body {
   cursor: not-allowed;
 }
 
+.subscribe-section[data-variant="3"] .subscribe-divider {
+  color: var(--text-secondary);
+  opacity: 0.5;
+  font-size: 0.95em;
+  padding: 0 0.2em;
+}
+
+.subscribe-section[data-variant="3"] .subscribe-x-link {
+  font-size: 0.95em;
+  font-family: inherit;
+  color: var(--color-orange);
+  text-decoration: none;
+  transition: transform 0.2s ease;
+  display: inline-block;
+}
+
+.subscribe-section[data-variant="3"] .subscribe-x-link:hover {
+  transform: translateX(2px);
+}
+
 @media screen and (max-width: 480px) {
   .subscribe-section[data-variant="3"] {
     padding: 0.75em 0;
@@ -787,6 +807,14 @@ body {
   .subscribe-section[data-variant="3"] button[type="submit"] {
     font-size: 0.85em;
     padding: 0.25em 0.4em;
+  }
+
+  .subscribe-section[data-variant="3"] .subscribe-x-link {
+    font-size: 0.85em;
+  }
+
+  .subscribe-section[data-variant="3"] .subscribe-divider {
+    font-size: 0.85em;
   }
 }
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -116,50 +116,59 @@ document.addEventListener('DOMContentLoaded', function() {
     console.error('Menu icon or menu items not found');
   }
 
-  // Newsletter form handling
-  const newsletterForm = document.getElementById('newsletter-form');
-  if (newsletterForm) {
-    const emailInput = document.getElementById('newsletter-email');
-    const submitButton = document.getElementById('newsletter-submit');
-    const formMessage = document.getElementById('form-message');
-
-    // TODO: Replace with your Google Apps Script deployment URL
+  // Newsletter form handling — supports multiple forms per page
+  const newsletterForms = document.querySelectorAll('.newsletter-form');
+  if (newsletterForms.length > 0) {
     const APPS_SCRIPT_URL = 'https://script.google.com/macros/s/AKfycbxSCkJCVFlVvAPvVJOJ3OyG4pBnfGsqTXZ6Zgl4Fn5H0rdPZgWMoTzMzL8VuVJBQ7Nftw/exec';
 
-    newsletterForm.addEventListener('submit', async function(e) {
-      e.preventDefault();
+    newsletterForms.forEach(form => {
+      const emailInput = form.querySelector('input[type="email"]');
+      const submitButton = form.querySelector('button[type="submit"]');
+      // form-message is a sibling of the form, inside the same container
+      const container = form.parentElement;
+      const formMessage = container ? container.querySelector('.form-message') : null;
 
-      const email = emailInput.value.trim();
-      if (!email) return;
+      form.addEventListener('submit', async function(e) {
+        e.preventDefault();
 
-      // Update UI to loading state
-      submitButton.disabled = true;
-      submitButton.textContent = 'Subscribing...';
-      formMessage.textContent = '';
-      formMessage.className = 'form-message';
+        const email = emailInput.value.trim();
+        if (!email) return;
 
-      try {
-        const response = await fetch(APPS_SCRIPT_URL, {
-          method: 'POST',
-          mode: 'no-cors', // Apps Script requires this
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ email: email })
-        });
+        // Update UI to loading state
+        submitButton.disabled = true;
+        submitButton.textContent = 'Subscribing...';
+        if (formMessage) {
+          formMessage.textContent = '';
+          formMessage.className = 'form-message';
+        }
 
-        // With no-cors, we can't read the response, so assume success
-        formMessage.textContent = 'Please check your inbox to confirm.';
-        formMessage.className = 'form-message success';
-        emailInput.value = '';
-      } catch (error) {
-        formMessage.textContent = 'Something went wrong. Please try again.';
-        formMessage.className = 'form-message error';
-        console.error('Newsletter subscription error:', error);
-      } finally {
-        submitButton.disabled = false;
-        submitButton.textContent = 'Subscribe';
-      }
+        try {
+          await fetch(APPS_SCRIPT_URL, {
+            method: 'POST',
+            mode: 'no-cors', // Apps Script requires this
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ email: email })
+          });
+
+          // With no-cors, we can't read the response, so assume success
+          if (formMessage) {
+            formMessage.textContent = 'Please check your inbox to confirm.';
+            formMessage.className = 'form-message success';
+          }
+          emailInput.value = '';
+        } catch (error) {
+          if (formMessage) {
+            formMessage.textContent = 'Something went wrong. Please try again.';
+            formMessage.className = 'form-message error';
+          }
+          console.error('Newsletter subscription error:', error);
+        } finally {
+          submitButton.disabled = false;
+          submitButton.textContent = 'Subscribe';
+        }
+      });
     });
   }
 });

--- a/index.markdown
+++ b/index.markdown
@@ -102,11 +102,11 @@ layout: default
       </span>
     </div>
     <div class="bento-subscribe-text">Get new posts delivered to your inbox. No spam, unsubscribe anytime.</div>
-    <form class="bento-subscribe-form" id="newsletter-form">
-      <input type="email" id="newsletter-email" name="email" placeholder="your@email.com" required autocomplete="email">
-      <button type="submit" id="newsletter-submit">Subscribe</button>
+    <form class="bento-subscribe-form newsletter-form">
+      <input type="email" name="email" placeholder="your@email.com" required autocomplete="email">
+      <button type="submit">Subscribe</button>
     </form>
-    <p class="form-message" id="form-message"></p>
+    <p class="form-message"></p>
   </div>
 
 </div>


### PR DESCRIPTION
Adds a second subscribe entry point right after the tl;dr in the Vercel
plugin telemetry post, featuring an email input, Subscribe button, and a
Follow on X link. Updates the shared subscribe-form include copy to match.
Refactors the newsletter form JS to support multiple forms per page via
class selectors instead of IDs.