### PR TITLE
fix: subscribe button formatting on mobile inline variant

### DIFF
--- a/assets/css/typewriter.css
+++ b/assets/css/typewriter.css
@@ -715,7 +715,8 @@ body {
 .subscribe-section[data-variant="3"] .subscribe-form-row {
   display: flex;
   align-items: center;
-  gap: 0.4em;
+  gap: 0.4em 0.6em;
+  flex-wrap: wrap;
 }
 
 .subscribe-section[data-variant="3"] input[type="email"] {
@@ -750,6 +751,11 @@ body {
   border: none;
   cursor: pointer;
   transition: transform 0.2s ease;
+  /* Opt out of the global 44x44 touch-target override for this compact inline button.
+     Tap area is provided via padding instead. */
+  min-height: 0;
+  min-width: 0;
+  line-height: 1.5;
 }
 
 .subscribe-section[data-variant="3"] button[type="submit"]:hover {
@@ -768,17 +774,23 @@ body {
   padding: 0 0.2em;
 }
 
-.subscribe-section[data-variant="3"] .subscribe-x-link {
+.subscribe-section[data-variant="3"] a.subscribe-x-link {
   font-size: 0.95em;
   font-family: inherit;
   color: var(--color-orange);
   text-decoration: none;
   transition: transform 0.2s ease;
   display: inline-block;
+  line-height: 1.5;
+  /* Opt out of the global 44x44 touch-target override for this compact inline link. */
+  min-height: 0;
+  min-width: 0;
 }
 
-.subscribe-section[data-variant="3"] .subscribe-x-link:hover {
+.subscribe-section[data-variant="3"] a.subscribe-x-link:hover {
   transform: translateX(2px);
+  color: var(--color-orange);
+  text-decoration: none;
 }
 
 @media screen and (max-width: 480px) {
@@ -792,29 +804,37 @@ body {
     flex-direction: column;
     align-items: flex-start;
     gap: 0.5em;
+    width: 100%;
   }
 
   .subscribe-section[data-variant="3"] .subscribe-text {
     font-size: 0.8em;
   }
 
+  .subscribe-section[data-variant="3"] .subscribe-form-row {
+    width: 100%;
+    row-gap: 0.5em;
+  }
+
   .subscribe-section[data-variant="3"] input[type="email"] {
-    width: 130px;
-    font-size: 0.8em;
-    padding: 0.3em 0.5em;
+    flex: 1 1 140px;
+    min-width: 0;
+    width: auto;
+    font-size: 0.85em;
+    padding: 0.35em 0.5em;
   }
 
   .subscribe-section[data-variant="3"] button[type="submit"] {
-    font-size: 0.85em;
-    padding: 0.25em 0.4em;
+    font-size: 0.9em;
+    padding: 0.35em 0.5em;
   }
 
-  .subscribe-section[data-variant="3"] .subscribe-x-link {
-    font-size: 0.85em;
+  .subscribe-section[data-variant="3"] a.subscribe-x-link {
+    font-size: 0.9em;
   }
 
   .subscribe-section[data-variant="3"] .subscribe-divider {
-    font-size: 0.85em;
+    font-size: 0.9em;
   }
 }
 


### PR DESCRIPTION
The inline subscribe row (variant 3) on the Vercel post looked broken on
mobile because the global `@media (hover: none) { a, button { min-height:
44px; min-width: 44px; } }` touch-target rule was forcing the compact
Subscribe button and "Follow on X" link to a 44px box, misaligning them
with the small email input next to them.

- Opt the variant-3 button and .subscribe-x-link out of the 44x44
  touch-target minimums; tap area is provided via padding instead.
- Bump `.subscribe-x-link` selector to `a.subscribe-x-link` for a hair
  more specificity so the orange color reliably beats the base `a` rule.
- Make the form row `flex-wrap: wrap` and give the input `flex: 1 1 140px`
  on mobile so the input grows to fill available width and the Follow on
  X link can drop to a second line gracefully on narrow screens.
- Tighten mobile font sizes and padding so the row reads as a single
  cohesive control group.