### PR TITLE
fix: dark mode text readability, theme toggle init, remove dead filter

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -11,14 +11,9 @@ document.addEventListener('DOMContentLoaded', function() {
     const savedTheme = localStorage.getItem('theme');
     const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     
-    if (savedTheme) {
-      document.documentElement.setAttribute('data-theme', savedTheme);
-      updateThemeIcon(savedTheme);
-    } else if (systemPrefersDark) {
-      updateThemeIcon('dark');
-    } else {
-      updateThemeIcon('light');
-    }
+    const activeTheme = savedTheme || (systemPrefersDark ? 'dark' : 'light');
+    document.documentElement.setAttribute('data-theme', activeTheme);
+    updateThemeIcon(activeTheme);
   }
 
   function updateThemeIcon(theme) {
@@ -33,18 +28,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
   function toggleTheme() {
     const currentTheme = document.documentElement.getAttribute('data-theme');
-    const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    
-    let newTheme;
-    if (currentTheme === 'dark') {
-      newTheme = 'light';
-    } else if (currentTheme === 'light') {
-      newTheme = 'dark';
-    } else {
-      // No explicit theme set, use opposite of system preference
-      newTheme = systemPrefersDark ? 'light' : 'dark';
-    }
-    
+    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
     document.documentElement.setAttribute('data-theme', newTheme);
     localStorage.setItem('theme', newTheme);
     updateThemeIcon(newTheme);
@@ -56,7 +40,9 @@ document.addEventListener('DOMContentLoaded', function() {
   // Listen for system theme changes
   window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
     if (!localStorage.getItem('theme')) {
-      updateThemeIcon(e.matches ? 'dark' : 'light');
+      const newTheme = e.matches ? 'dark' : 'light';
+      document.documentElement.setAttribute('data-theme', newTheme);
+      updateThemeIcon(newTheme);
     }
   });
 

--- a/side-projects.markdown
+++ b/side-projects.markdown
@@ -6,20 +6,20 @@ permalink: /side-projects/
 
 ## Things I've built, with my bestie Claude Code 🧡
 
-- <a href="https://fourplay.fun" target="_blank" rel="noopener noreferrer">FourPlay</a> <span style="float: right; color: #888;"><small>15 Feb 2026</small></span>
-  <div style="color: #666;">Wordle meets numbers - multiplayer guessing game, specially fun for couples :).</div>
+- <a href="https://fourplay.fun" target="_blank" rel="noopener noreferrer">FourPlay</a> <span style="float: right; color: var(--text-secondary);"><small>15 Feb 2026</small></span>
+  <div style="color: var(--text-secondary);">Wordle meets numbers - multiplayer guessing game, specially fun for couples :).</div>
 
-- <a href="https://blunderbuddy.pro/" target="_blank" rel="noopener noreferrer">BlunderBuddy</a> <span style="float: right; color: #888;"><small>01 Jul 2025</small></span>
-  <div style="color: #666;">AI-powered personalized chess insights that actually make sense.</div>
+- <a href="https://blunderbuddy.pro/" target="_blank" rel="noopener noreferrer">BlunderBuddy</a> <span style="float: right; color: var(--text-secondary);"><small>01 Jul 2025</small></span>
+  <div style="color: var(--text-secondary);">AI-powered personalized chess insights that actually make sense.</div>
 
-- <a href="https://simpleeval.com/" target="_blank" rel="noopener noreferrer">Simple Eval</a> <span style="float: right; color: #888;"><small>01 Jun 2025</small></span>
-  <div style="color: #666;">Connect your vibecoded app & get auto-suggest evals to improve performance.</div>
+- <a href="https://simpleeval.com/" target="_blank" rel="noopener noreferrer">Simple Eval</a> <span style="float: right; color: var(--text-secondary);"><small>01 Jun 2025</small></span>
+  <div style="color: var(--text-secondary);">Connect your vibecoded app & get auto-suggest evals to improve performance.</div>
 
-- <a href="https://quickyap.akshaychugh.xyz/" target="_blank" rel="noopener noreferrer">quickyap</a> <span style="float: right; color: #888;"><small>01 Dec 2024</small></span>
-  <div style="color: #666;">Get your computer to work at the speed of your thoughts. Just speak and get instant text in any app.</div>
+- <a href="https://quickyap.akshaychugh.xyz/" target="_blank" rel="noopener noreferrer">quickyap</a> <span style="float: right; color: var(--text-secondary);"><small>01 Dec 2024</small></span>
+  <div style="color: var(--text-secondary);">Get your computer to work at the speed of your thoughts. Just speak and get instant text in any app.</div>
 
-- <a href="https://better-reads.akshaychugh.xyz/" target="_blank" rel="noopener noreferrer">better-reads</a> <span style="float: right; color: #888;"><small>05 Nov 2024</small></span>
-  <div style="color: #666;">A better way to discover book recommendations from your endless goodreads library!</div>
+- <a href="https://better-reads.akshaychugh.xyz/" target="_blank" rel="noopener noreferrer">better-reads</a> <span style="float: right; color: var(--text-secondary);"><small>05 Nov 2024</small></span>
+  <div style="color: var(--text-secondary);">A better way to discover book recommendations from your endless goodreads library!</div>
 
 
 

--- a/writings.markdown
+++ b/writings.markdown
@@ -11,7 +11,6 @@ permalink: /writings/
 <button class="wr-filter" onclick="filterWritings('png', this)">product & growth</button>
 <button class="wr-filter" onclick="filterWritings('life', this)">life</button>
 <button class="wr-filter" onclick="filterWritings('fitness', this)">fitness</button>
-<button class="wr-filter" onclick="filterWritings('web3', this)">web3</button>
 </div>
 
 {% assign empty_array = "" | split: "," %}


### PR DESCRIPTION
- side-projects: replace hardcoded #888/#666 with var(--text-secondary) so text stays readable in dark mode
- script.js: always set data-theme on <html> during init so the page actually matches the icon on first load; simplify toggleTheme accordingly
- writings: remove web3 filter button since no posts use that category