### PR TITLE
Scrollable bento sections on homepage

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,0 +1,24 @@
+- name: FourPlay
+  url: https://fourplay.fun
+  date: 2026-02-15
+  description: "Wordle meets numbers - multiplayer guessing game, specially fun for couples :)."
+
+- name: BlunderBuddy
+  url: https://blunderbuddy.pro/
+  date: 2025-07-01
+  description: "AI-powered personalized chess insights that actually make sense."
+
+- name: Simple Eval
+  url: https://simpleeval.com/
+  date: 2025-06-01
+  description: "Connect your vibecoded app & get auto-suggest evals to improve performance."
+
+- name: quickyap
+  url: https://quickyap.akshaychugh.xyz/
+  date: 2024-12-01
+  description: "Get your computer to work at the speed of your thoughts. Just speak and get instant text in any app."
+
+- name: better-reads
+  url: https://better-reads.akshaychugh.xyz/
+  date: 2024-11-05
+  description: "A better way to discover book recommendations from your endless goodreads library!"

--- a/assets/css/typewriter.css
+++ b/assets/css/typewriter.css
@@ -862,6 +862,17 @@ body {
 .bento-github-chart {
   width: 100%;
   border-radius: 4px;
+  transition: filter 0.3s ease;
+}
+
+[data-theme="dark"] .bento-github-chart {
+  filter: invert(1) hue-rotate(180deg) brightness(1.1) saturate(1.35) contrast(0.92);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .bento-github-chart {
+    filter: invert(1) hue-rotate(180deg) brightness(1.1) saturate(1.35) contrast(0.92);
+  }
 }
 
 .bento-intro-bio {
@@ -942,6 +953,37 @@ body {
   margin: 0;
 }
 
+/* Scrollable list inside tiles that have a lot of content */
+.bento-tile--scroll {
+  display: flex;
+  flex-direction: column;
+}
+
+.bento-list--scroll {
+  max-height: 420px;
+  overflow-y: auto;
+  padding-right: 8px;
+  margin-right: -8px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-base-200) transparent;
+  -webkit-mask-image: linear-gradient(to bottom, black calc(100% - 24px), transparent 100%);
+          mask-image: linear-gradient(to bottom, black calc(100% - 24px), transparent 100%);
+}
+
+.bento-list--scroll-sm {
+  max-height: 200px;
+}
+
+.bento-list--scroll::-webkit-scrollbar { width: 6px; }
+.bento-list--scroll::-webkit-scrollbar-track { background: transparent; }
+.bento-list--scroll::-webkit-scrollbar-thumb {
+  background: var(--color-base-200);
+  border-radius: 3px;
+}
+.bento-list--scroll::-webkit-scrollbar-thumb:hover {
+  background: var(--color-base-300);
+}
+
 .bento-list li {
   padding: 8px 0;
   border-bottom: 1px solid var(--color-base-50);
@@ -996,7 +1038,19 @@ body {
   font-size: inherit;
 }
 
-/* Subscribe tile in bento */
+/* Subscribe tile in bento — center content vertically when row stretches */
+.bento-tile--subscribe {
+  display: flex;
+  flex-direction: column;
+}
+
+.bento-subscribe-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
 .bento-subscribe-text {
   font-size: 14px;
   color: var(--text-secondary);

--- a/index.markdown
+++ b/index.markdown
@@ -20,7 +20,15 @@ layout: default
     </div>
   </div>
 
-  <div class="bento-tile">
+  {% assign empty_array = "" | split: "," %}
+  {% assign writings_posts = empty_array %}
+  {% if site.categories.png %}{% assign writings_posts = writings_posts | concat: site.categories.png %}{% endif %}
+  {% if site.categories.fitness %}{% assign writings_posts = writings_posts | concat: site.categories.fitness %}{% endif %}
+  {% if site.categories.life %}{% assign writings_posts = writings_posts | concat: site.categories.life %}{% endif %}
+  {% if site.categories.web3 %}{% assign writings_posts = writings_posts | concat: site.categories.web3 %}{% endif %}
+  {% assign writings_posts = writings_posts | sort: 'date' | reverse %}
+
+  <div class="bento-tile bento-tile--scroll">
     <div class="bento-label">
       <span class="bento-label-left">
         <span class="bento-label-dot"></span>
@@ -28,31 +36,17 @@ layout: default
       </span>
       <a href="/writings/" class="bento-view-all">View all &rarr;</a>
     </div>
-    <ul class="bento-list">
+    <ul class="bento-list bento-list--scroll">
+      {% for post in writings_posts %}
       <li>
-        <a href="/writings/png/vercel-plugin-telemetry-update">What Happened After My Vercel Plugin Post Hit #1 on Hacker News</a>
-        <div class="bento-item-date">Apr 2026</div>
+        <a href="{{ post.url }}">{{ post.title }}</a>
+        <div class="bento-item-date">{{ post.date | date: "%b %Y" }}</div>
       </li>
-      <li>
-        <a href="/writings/png/vercel-plugin-telemetry">The Vercel Plugin on Claude Code wants to read all your prompts!</a>
-        <div class="bento-item-date">Apr 2026</div>
-      </li>
-      <li>
-        <a href="/writings/png/how-does-g2-survive">How does G2 survive?</a>
-        <div class="bento-item-date">Mar 2026</div>
-      </li>
-      <li>
-        <a href="/writings/png/how-claude-code-chooses">How Claude Code Chooses - A deep dive on email providers</a>
-        <div class="bento-item-date">Feb 2026</div>
-      </li>
-      <li>
-        <a href="/writings/life/you-are-average-but-so-are-your-problems">You are average, but so are your problems</a>
-        <div class="bento-item-date">Feb 2026</div>
-      </li>
+      {% endfor %}
     </ul>
   </div>
 
-  <div class="bento-tile">
+  <div class="bento-tile bento-tile--scroll">
     <div class="bento-label">
       <span class="bento-label-left">
         <span class="bento-label-dot"></span>
@@ -60,23 +54,18 @@ layout: default
       </span>
       <a href="/side-projects/" class="bento-view-all">View all &rarr;</a>
     </div>
-    <ul class="bento-list">
+    <ul class="bento-list bento-list--scroll">
+      {% assign projects = site.data.projects | sort: 'date' | reverse %}
+      {% for project in projects %}
       <li>
-        <a href="https://fourplay.fun" target="_blank" rel="noopener noreferrer">FourPlay</a>
-        <div class="bento-project-desc">Wordle meets numbers - multiplayer guessing game, specially fun for couples :).</div>
+        <a href="{{ project.url }}" target="_blank" rel="noopener noreferrer">{{ project.name }}</a>
+        <div class="bento-project-desc">{{ project.description }}</div>
       </li>
-      <li>
-        <a href="https://blunderbuddy.pro/" target="_blank" rel="noopener noreferrer">BlunderBuddy</a>
-        <div class="bento-project-desc">AI-powered personalized chess insights that actually make sense.</div>
-      </li>
-      <li>
-        <a href="https://simpleeval.com/" target="_blank" rel="noopener noreferrer">Simple Eval</a>
-        <div class="bento-project-desc">Connect your vibecoded app & get auto-suggest evals to improve performance.</div>
-      </li>
+      {% endfor %}
     </ul>
   </div>
 
-  <div class="bento-tile">
+  <div class="bento-tile bento-tile--scroll">
     <div class="bento-label">
       <span class="bento-label-left">
         <span class="bento-label-dot"></span>
@@ -84,8 +73,9 @@ layout: default
       </span>
       <a href="/til/" class="bento-view-all">View all &rarr;</a>
     </div>
-    <ul class="bento-list">
-      {% for til in site.data.til limit:2 %}
+    <ul class="bento-list bento-list--scroll bento-list--scroll-sm">
+      {% assign tils = site.data.til | sort: 'date' | reverse %}
+      {% for til in tils %}
       <li>
         <div class="bento-til-text">{{ til.title | markdownify | remove: '<p>' | remove: '</p>' }}</div>
         <div class="bento-item-date">{{ til.date | date: "%b %-d, %Y" }}</div>
@@ -94,19 +84,21 @@ layout: default
     </ul>
   </div>
 
-  <div class="bento-tile">
+  <div class="bento-tile bento-tile--subscribe">
     <div class="bento-label">
       <span class="bento-label-left">
         <span class="bento-label-dot"></span>
         Subscribe
       </span>
     </div>
+    <div class="bento-subscribe-body">
     <div class="bento-subscribe-text">Get new posts delivered to your inbox. No spam, unsubscribe anytime.</div>
     <form class="bento-subscribe-form" id="newsletter-form">
       <input type="email" id="newsletter-email" name="email" placeholder="your@email.com" required autocomplete="email">
       <button type="submit" id="newsletter-submit">Subscribe</button>
     </form>
     <p class="form-message" id="form-message"></p>
+    </div>
   </div>
 
 </div>

--- a/side-projects.markdown
+++ b/side-projects.markdown
@@ -6,20 +6,11 @@ permalink: /side-projects/
 
 ## Things I've built, with my bestie Claude Code 🧡
 
-- <a href="https://fourplay.fun" target="_blank" rel="noopener noreferrer">FourPlay</a> <span style="float: right; color: var(--text-secondary);"><small>15 Feb 2026</small></span>
-  <div style="color: var(--text-secondary);">Wordle meets numbers - multiplayer guessing game, specially fun for couples :).</div>
-
-- <a href="https://blunderbuddy.pro/" target="_blank" rel="noopener noreferrer">BlunderBuddy</a> <span style="float: right; color: var(--text-secondary);"><small>01 Jul 2025</small></span>
-  <div style="color: var(--text-secondary);">AI-powered personalized chess insights that actually make sense.</div>
-
-- <a href="https://simpleeval.com/" target="_blank" rel="noopener noreferrer">Simple Eval</a> <span style="float: right; color: var(--text-secondary);"><small>01 Jun 2025</small></span>
-  <div style="color: var(--text-secondary);">Connect your vibecoded app & get auto-suggest evals to improve performance.</div>
-
-- <a href="https://quickyap.akshaychugh.xyz/" target="_blank" rel="noopener noreferrer">quickyap</a> <span style="float: right; color: var(--text-secondary);"><small>01 Dec 2024</small></span>
-  <div style="color: var(--text-secondary);">Get your computer to work at the speed of your thoughts. Just speak and get instant text in any app.</div>
-
-- <a href="https://better-reads.akshaychugh.xyz/" target="_blank" rel="noopener noreferrer">better-reads</a> <span style="float: right; color: var(--text-secondary);"><small>05 Nov 2024</small></span>
-  <div style="color: var(--text-secondary);">A better way to discover book recommendations from your endless goodreads library!</div>
+{% assign projects = site.data.projects | sort: 'date' | reverse %}
+{% for project in projects %}
+- <a href="{{ project.url }}" target="_blank" rel="noopener noreferrer">{{ project.name }}</a> <span style="float: right; color: var(--text-secondary);"><small>{{ project.date | date: "%d %b %Y" }}</small></span>
+  <div style="color: var(--text-secondary);">{{ project.description }}</div>
+{% endfor %}
 
 
 


### PR DESCRIPTION
## Summary

- Homepage bento tiles (Writings, Side Projects, Today I Learnt) now show all items and scroll within a max-height, instead of being frozen at the top 5 / top 2
- Writings list loops dynamically over `png/life/fitness/web3` categories — new posts will auto-appear
- Side Projects now sources from a new `_data/projects.yml`; `side-projects.markdown` was rewired to the same data file so the two views can't drift
- Dark-mode styling for the GitHub contribution chart (the external SVG's white background looked jarring against the dark tile)
- Subscribe tile content now vertically centers when its grid row stretches

## Notes for reviewer

- TIL tile deliberately uses a smaller max-height (`200px`) so the Subscribe tile next to it doesn't get forced to a tall, empty-looking height
- GitHub chart fix uses `filter: invert(1) hue-rotate(180deg)` plus brightness/saturate/contrast tweaks — green cells stay green, white background flips to dark

## Test plan

- [ ] Homepage bento: Writings / Side Projects / TIL each scroll internally with a fade-mask at the bottom
- [ ] Light and dark mode both look clean (chart, scrollbar, fade mask)
- [ ] `/side-projects/` page still renders the full project list
- [ ] Mobile (<640px): tiles stack, lists still scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)