### PR TITLE
add til: OTT hybrid-tier ARPU is surprisingly highest (Disney+ split)

### DIFF
--- a/_data/til.yml
+++ b/_data/til.yml
@@ -1,3 +1,6 @@
+- date: 2026-04-19
+  title: "For a lot of OTTs and streaming players, ARPU is 'surprisingly' highest for the hybrid tier (lower fee + ads), not the premium ad-free tier - Bob Iger [accidentally revealed](https://whatsondisneyplus.com/disney-ceo-bob-iger-accidentally-reveals-disney-ad-supported-subscriber-details/) Disney+'s internal split"
+
 - date: 2026-03-01
   title: "CRED hijacks the UPI remarks field to advertise inside GPay's transaction history - *'Paid via CRED and got cashback'* shows up in the receiver's app"
   details: |


### PR DESCRIPTION
## Summary
- New TIL entry dated 2026-04-19: for many OTTs/streaming players, ARPU is *surprisingly* highest on the hybrid tier (lower fee + ads), not the ad-free premium tier — Bob Iger [accidentally revealed](https://whatsondisneyplus.com/disney-ceo-bob-iger-accidentally-reveals-disney-ad-supported-subscriber-details/) Disney+'s internal split
- Single-line title-only entry (matches the shape of the Jan 31 Netflix and Feb 15 Lego entries)
- Lands at the top of the timeline since newer dates sort first

## Test plan
- [ ] GitHub Pages deploys the preview — check akshaychugh.xyz/til/ shows **April 2026 / 19th** as the newest entry
- [ ] Link on "accidentally revealed" opens the whatsondisneyplus.com article in a new tab
- [ ] 'surprisingly' renders with straight quotes, no YAML escape artifacts
- [ ] Dark mode and mobile layouts render the long title without breaking

🤖 Generated with [Claude Code](https://claude.com/claude-code)